### PR TITLE
Codacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Core utilities for Virtool and associated packages.
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/f04b88f74f2640588ba7dec5022c9b51)](https://www.codacy.com/gh/virtool/virtool-core/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=virtool/virtool-core&amp;utm_campaign=Badge_Grade)
+
 # Install
 
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
-from .fixtures import  *
+pytest_plugins = [
+    "tests.fixtures.__init__"
+]
 
 
 def pytest_addoption(parser):

--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -2,7 +2,6 @@ import pymongo
 import motor.motor_asyncio
 import pytest
 from aiohttp.test_utils import make_mocked_coro
-from virtool_core import db
 
 
 class MockDeleteResult:

--- a/tests/fixtures/history.py
+++ b/tests/fixtures/history.py
@@ -43,10 +43,7 @@ def test_changes(test_change):
 
 @pytest.fixture
 def test_otu_edit():
-    """
-    An :class:`tuple` containing old and new otu documents for testing history diffing.
-
-    """
+    """An :class:`tuple` containing old and new otu documents for testing history diffing."""
     return (
         {
             "_id": "6116cba1",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,10 +61,7 @@ class TestRandomAlphanumeric:
     (False, {"foo.txt", "baz"})
 ])
 def test_rm(recursive, expected, tmpdir):
-    """
-    Test that a file can be removed and that a folder can be removed when `recursive` is set to `True`.
-
-    """
+    """Test that a file can be removed and that a folder can be removed when `recursive` is set to `True`."""
     tmpdir.join("foo.txt").write("hello world")
     tmpdir.join("bar.txt").write("hello world")
     tmpdir.mkdir("baz")

--- a/virtool_core/utils.py
+++ b/virtool_core/utils.py
@@ -15,8 +15,8 @@ def ensure_data_dir(data_path):
     """
     Ensure the application data structure is correct. Fix it if it is broken.
     :param data_path: the path to create the data folder structure in
-    """
 
+    """
     subdirectories = [
         "caches",
         "files",


### PR DESCRIPTION
Fix some Codacy issues and get rid of unused import warnings by using a different fixture collection strategy for pytest.