### PR TITLE
fix: reduce minimal user model

### DIFF
--- a/virtool_core/models/user.py
+++ b/virtool_core/models/user.py
@@ -10,11 +10,11 @@ class UserMinimal(BaseModel):
     id: str
     handle: str
     administrator: bool
-    force_reset: bool
-    groups: List[Group]
-    last_password_change: datetime
-    primary_group: str
 
 
 class User(UserMinimal):
+    force_reset: bool
+    groups: List[Group]
+    last_password_change: datetime
     permissions: Permissions
+    primary_group: str


### PR DESCRIPTION
Move several fields to the full model. The minimal model was too big.

BREAKING CHANGE: This remove fields from the minimal user representation.