### PR TITLE
fix: add an id-only minimal group model

### DIFF
--- a/virtool_core/models/group.py
+++ b/virtool_core/models/group.py
@@ -5,6 +5,7 @@ class Permissions(BaseModel):
     """
     The permissions possessed by a user and group.
     """
+
     cancel_job: bool = False
     create_ref: bool = False
     create_sample: bool = False
@@ -15,9 +16,9 @@ class Permissions(BaseModel):
     upload_file: bool = False
 
 
-class Group(BaseModel):
-    """
-    A Virtool user group.
-    """
-    permissions: Permissions
+class GroupMinimal(BaseModel):
     id: str
+
+
+class Group(GroupMinimal):
+    permissions: Permissions

--- a/virtool_core/models/user.py
+++ b/virtool_core/models/user.py
@@ -3,7 +3,7 @@ from typing import List
 
 from pydantic import BaseModel
 
-from virtool_core.models.group import Group, Permissions
+from virtool_core.models.group import Permissions, GroupMinimal
 
 
 class UserMinimal(BaseModel):
@@ -14,7 +14,7 @@ class UserMinimal(BaseModel):
 
 class User(UserMinimal):
     force_reset: bool
-    groups: List[Group]
+    groups: List[GroupMinimal]
     last_password_change: datetime
     permissions: Permissions
-    primary_group: str
+    primary_group: GroupMinimal


### PR DESCRIPTION
I am adding this because the `Group` model with the `permissions` field is excessive for nesting in `User` models. This minimal model does not have the `permissions` field.