### PR TITLE
fix: remove subtraction field from SampleMinimal

### DIFF
--- a/virtool_core/models/samples.py
+++ b/virtool_core/models/samples.py
@@ -25,7 +25,6 @@ class SampleMinimal(SampleID):
     nuvs: bool
     pathoscope: bool
     ready: bool
-    subtractions: List[SubtractionNested]
     user: UserMinimal
 
 
@@ -78,6 +77,7 @@ class Sample(SampleMinimal):
     paired: bool
     quality: Quality
     reads: List[Read]
+    subtractions: List[SubtractionNested]
 
 
 class SampleSearchResult(SearchResult):


### PR DESCRIPTION
This should be only in complete sample representations. Move it into `Sample` from `SampleMinimal`.