### PR TITLE
fix: allow strings for sample workflow tag fields

### DIFF
--- a/virtool_core/models/samples.py
+++ b/virtool_core/models/samples.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Union, TYPE_CHECKING, Optional
 
+from pydantic import Field
+
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.enums import LibraryType
 from virtool_core.models.label import LabelNested
@@ -29,8 +31,8 @@ class SampleMinimal(SampleNested):
     labels: List[LabelNested]
     library_type: LibraryType
     notes: str
-    nuvs: bool
-    pathoscope: bool
+    nuvs: Union[str, bool]
+    pathoscope: Union[str, bool]
     ready: bool
     user: UserNested
 

--- a/virtool_core/models/samples.py
+++ b/virtool_core/models/samples.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Union, TYPE_CHECKING, Optional
 
-from pydantic import Field
-
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.enums import LibraryType
 from virtool_core.models.label import LabelNested


### PR DESCRIPTION
Workflow tags with workflows still in-progress have the value `"ip"`.

This is a stupid design and should be changed to an enum value (eg. `none`, `pending`, `ready`).