### PR TITLE
fix: remove hmm hidden field

### DIFF
--- a/virtool_core/models/hmm.py
+++ b/virtool_core/models/hmm.py
@@ -71,7 +71,6 @@ class HMMSequenceEntry(BaseModel):
 class HMM(HMMMinimal):
     entries: List[HMMSequenceEntry]
     genera: Dict[str, int]
-    hidden: bool
     length: int
     mean_entropy: float
     total_entropy: float


### PR DESCRIPTION
This field should never be sent in responses. It is a flag indicating that the HMM is invisible to users.