### PR TITLE
feat: add model for upload search result

### DIFF
--- a/virtool_core/models/upload.py
+++ b/virtool_core/models/upload.py
@@ -28,4 +28,4 @@ Upload = UploadMinimal
 
 
 class UploadSearchResult(BaseModel):
-    documents: List[Upload]
+    documents: List[UploadMinimal]

--- a/virtool_core/models/upload.py
+++ b/virtool_core/models/upload.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.user import UserMinimal
@@ -25,3 +25,7 @@ class UploadMinimal(BaseModel):
 
 
 Upload = UploadMinimal
+
+
+class UploadSearchResult(BaseModel):
+    documents: List[Upload]


### PR DESCRIPTION
Used BaseModel instead of SearchResult since pagination is not used in uploads.