### PR TITLE
fix: make substraction count optional

### DIFF
--- a/virtool_core/models/subtraction.py
+++ b/virtool_core/models/subtraction.py
@@ -43,7 +43,7 @@ class SubtractionMinimal(SubtractionNested):
     Minimal Subtraction model used for websocket messages and resource listings.
     """
 
-    count: int
+    count: Optional[int]
     created_at: datetime
     file: SubtractionUpload
     nickname: str


### PR DESCRIPTION
This value isn't set until after the creation workflow finishes.