### PR TITLE
fix: make subtraction user field optional

### DIFF
--- a/virtool_core/models/subtraction.py
+++ b/virtool_core/models/subtraction.py
@@ -48,7 +48,7 @@ class SubtractionMinimal(SubtractionNested):
     file: SubtractionUpload
     nickname: str
     ready: bool
-    user: UserNested
+    user: Optional[UserNested]
 
 
 class Subtraction(SubtractionMinimal):


### PR DESCRIPTION
For older subtractions, user information was not retained.