### PR TITLE
fix: use nested users in most places

### DIFF
--- a/virtool_core/models/__init__.py
+++ b/virtool_core/models/__init__.py
@@ -4,8 +4,6 @@ from virtool_core.models import samples
 from virtool_core.models import subtraction
 
 
-group.Group.update_forward_refs(UserMinimal=user.UserMinimal)
-samples.Sample.update_forward_refs(
-    SubtractionNested=subtraction.SubtractionNested
-)
+group.Group.update_forward_refs(UserNested=user.UserNested)
+samples.Sample.update_forward_refs(SubtractionNested=subtraction.SubtractionNested)
 subtraction.Subtraction.update_forward_refs(SampleNested=samples.SampleNested)

--- a/virtool_core/models/analysis.py
+++ b/virtool_core/models/analysis.py
@@ -9,7 +9,7 @@ from virtool_core.models.job import JobNested
 from virtool_core.models.reference import AnalysisReference
 from virtool_core.models.searchresult import SearchResult
 from virtool_core.models.subtraction import SubtractionNested
-from virtool_core.models.user import UserMinimal
+from virtool_core.models.user import UserNested
 
 
 class AnalysisSample(BaseModel):
@@ -26,7 +26,7 @@ class AnalysisMinimal(BaseModel):
     sample: AnalysisSample
     subtractions: List[SubtractionNested]
     updated_at: datetime
-    user: UserMinimal
+    user: UserNested
     workflow: str
 
     @root_validator(pre=True)

--- a/virtool_core/models/group.py
+++ b/virtool_core/models/group.py
@@ -7,7 +7,7 @@ from pydantic import validator, constr
 from virtool_core.models.basemodel import BaseModel
 
 if TYPE_CHECKING:
-    from virtool_core.models.user import UserMinimal
+    from virtool_core.models.user import UserNested
 
 
 class Permissions(BaseModel):
@@ -39,4 +39,4 @@ class GroupMinimal(BaseModel):
 
 class Group(GroupMinimal):
     permissions: Permissions
-    users: List[UserMinimal]
+    users: List[UserNested]

--- a/virtool_core/models/history.py
+++ b/virtool_core/models/history.py
@@ -5,7 +5,7 @@ from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.enums import HistoryMethod
 from virtool_core.models.reference import ReferenceNested
 from virtool_core.models.searchresult import SearchResult
-from virtool_core.models.user import UserMinimal
+from virtool_core.models.user import UserNested
 
 
 class HistoryIndex(BaseModel):
@@ -40,9 +40,9 @@ class HistoryNested(BaseModel):
     The name of the method that made the change (eg. edit_sequence). 
     """
 
-    user: UserMinimal
+    user: UserNested
     """
-    Minimal information for the user that made the change.
+    Identifying information for the user that made the change.
     """
 
 

--- a/virtool_core/models/index.py
+++ b/virtool_core/models/index.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.job import JobMinimal
 from virtool_core.models.reference import ReferenceMinimal
-from virtool_core.models.user import UserMinimal
+from virtool_core.models.user import UserNested
 
 
 class IndexNested(BaseModel):
@@ -19,10 +19,10 @@ class IndexMinimal(IndexNested):
     job: JobMinimal
     modified_otu_count: int
     reference: ReferenceMinimal
-    user: UserMinimal
+    user: UserNested
 
 
-class IndexContributor(UserMinimal):
+class IndexContributor(UserNested):
     count: int
 
 

--- a/virtool_core/models/project.py
+++ b/virtool_core/models/project.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from pydantic import validator
 
 from virtool_core.models.basemodel import BaseModel
-from virtool_core.models.user import UserMinimal
+from virtool_core.models.user import UserNested
 from virtool_core.models.validators import normalize_hex_color
 
 

--- a/virtool_core/models/project.py
+++ b/virtool_core/models/project.py
@@ -24,7 +24,7 @@ class ProjectMinimal(BaseModel):
     #: The display color for the project.
     color: str
     #: The user that created the project.
-    user: UserMinimal
+    user: UserNested
 
     # Validators
     _normalize_color = validator("color", allow_reuse=True)(normalize_hex_color)
@@ -41,4 +41,4 @@ class Project(ProjectMinimal):
     #: The samples organized under the project.
     samples: Optional[List[str]] = None
     #: The users that have access to the project.
-    users: Optional[List[UserMinimal]] = None
+    users: Optional[List[UserNested]] = None

--- a/virtool_core/models/reference.py
+++ b/virtool_core/models/reference.py
@@ -4,7 +4,7 @@ from typing import List, Any
 
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.task import Task
-from virtool_core.models.user import UserMinimal
+from virtool_core.models.user import UserMinimal, UserNested
 
 
 class ReferenceClonedFrom(BaseModel):
@@ -17,7 +17,7 @@ class ReferenceDataType(str, enum.Enum):
     genome = "genome"
 
 
-class ReferenceUser(UserMinimal):
+class ReferenceUser(UserNested):
     count: int
     build: bool
     created_at: datetime
@@ -42,7 +42,7 @@ class ReferenceInstalled(BaseModel):
     published_at: datetime
     ready: bool
     size: int
-    user: UserMinimal
+    user: UserNested
 
 
 class ReferenceRelease(BaseModel):
@@ -64,7 +64,7 @@ class ReferenceBuild(BaseModel):
     created_at: datetime
     id: str
     version: int
-    user: UserMinimal
+    user: UserNested
     has_json: bool
 
 
@@ -91,7 +91,7 @@ class ReferenceMinimal(AnalysisReference):
     task: Task
     updating: bool = None
     unbuilt_change_count: int
-    user: UserMinimal
+    user: UserNested
     users: List[ReferenceUser]
 
 

--- a/virtool_core/models/reference.py
+++ b/virtool_core/models/reference.py
@@ -4,7 +4,7 @@ from typing import List, Any
 
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.task import Task
-from virtool_core.models.user import UserMinimal, UserNested
+from virtool_core.models.user import UserNested
 
 
 class ReferenceClonedFrom(BaseModel):

--- a/virtool_core/models/upload.py
+++ b/virtool_core/models/upload.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, List
 
 from virtool_core.models.basemodel import BaseModel
-from virtool_core.models.user import UserMinimal
+from virtool_core.models.user import UserNested
 
 
 class UploadMinimal(BaseModel):
@@ -21,7 +21,7 @@ class UploadMinimal(BaseModel):
     size: Optional[int]
     type: str
     uploaded_at: Optional[datetime]
-    user: UserMinimal
+    user: UserNested
 
 
 Upload = UploadMinimal


### PR DESCRIPTION
`UserMinimal` is too detailed to be nested in most models. This PR replaces uses of `UserMinimal` with `UserNested` in many places.