### PR TITLE
feat: update reference and index models

### DIFF
--- a/virtool_core/models/index.py
+++ b/virtool_core/models/index.py
@@ -21,6 +21,7 @@ class IndexMinimal(IndexNested):
     modified_otu_count: int
     reference: ReferenceNested
     user: UserNested
+    ready: bool
 
 
 class IndexContributor(UserNested):
@@ -47,10 +48,10 @@ class Index(IndexMinimal):
     files: List[IndexFile]
     manifest: Dict[str, int]
     otus: List[IndexOTU]
-    ready: bool
 
 
 class IndexSearchResult(SearchResult):
     documents: List[IndexMinimal]
     modified_otu_count: int
     total_otu_count: int
+    change_count: int

--- a/virtool_core/models/reference.py
+++ b/virtool_core/models/reference.py
@@ -109,7 +109,7 @@ class ReferenceMinimal(AnalysisReference):
     unbuilt_change_count: int
     user: UserNested
     users: List[ReferenceUser]
-    imported_from: Upload = None
+    imported_from: Optional[Upload] = None
 
 
 class Reference(ReferenceMinimal):

--- a/virtool_core/models/reference.py
+++ b/virtool_core/models/reference.py
@@ -5,6 +5,7 @@ from typing import List, Any, Optional
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.searchresult import SearchResult
 from virtool_core.models.task import TaskNested
+from virtool_core.models.upload import Upload
 from virtool_core.models.user import UserNested
 
 
@@ -27,6 +28,7 @@ class ReferenceRights(BaseModel):
 
 class ReferenceGroup(ReferenceRights):
     id: str
+    created_at: datetime
 
 
 class ReferenceUser(ReferenceRights):
@@ -107,6 +109,7 @@ class ReferenceMinimal(AnalysisReference):
     unbuilt_change_count: int
     user: UserNested
     users: List[ReferenceUser]
+    imported_from: Upload = None
 
 
 class Reference(ReferenceMinimal):
@@ -114,6 +117,7 @@ class Reference(ReferenceMinimal):
     description: str
     restrict_source_types: bool
     source_types: List[str]
+    targets: Optional[List[dict]]
 
 
 class ReferenceSearchResult(SearchResult):


### PR DESCRIPTION
Index models:

Added change_count to IndexSearchResult and moved ready to IndexMinimal.

Reference models:

Added created_at to ReferenceGroup which was missed in the last PR. Also added imported_from to ReferenceMinimal and
targets to Reference in case the data_type is "barcode"

Did not change data_type and organism to be Optional as I believe those fields being None is a bug.