### PR TITLE
feat: add session model

### DIFF
--- a/virtool_core/models/session.py
+++ b/virtool_core/models/session.py
@@ -16,7 +16,7 @@ class SessionAuthentication(BaseModel):
     user: UserNested
 
 
-class SessionReset(BaseModel):
+class SessionPasswordReset(BaseModel):
     code: str
     remember: bool
     user_id: str
@@ -24,6 +24,6 @@ class SessionReset(BaseModel):
 
 class Session(BaseModel):
     authentication: Optional[SessionAuthentication]
-    reset: Optional[SessionReset]
+    reset: Optional[SessionPasswordReset]
     created_at: datetime
     ip: str

--- a/virtool_core/models/session.py
+++ b/virtool_core/models/session.py
@@ -1,19 +1,12 @@
 from datetime import datetime
-
-from typing import List, Optional
+from typing import Optional
 
 from virtool_core.models.basemodel import BaseModel
-from virtool_core.models.enums import Permission
-from virtool_core.models.group import Group
-from virtool_core.models.user import UserNested
 
 
 class SessionAuthentication(BaseModel):
     token: str
-    groups: List[Group]
-    permissions: Permission
-    force_reset: bool
-    user: UserNested
+    user_id: str
 
 
 class SessionPasswordReset(BaseModel):

--- a/virtool_core/models/session.py
+++ b/virtool_core/models/session.py
@@ -16,6 +16,3 @@ class Session(BaseModel):
     permissions: Permission
     force_reset: bool
     user: UserNested
-
-
-

--- a/virtool_core/models/session.py
+++ b/virtool_core/models/session.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from typing import List
+
+from virtool_core.models.basemodel import BaseModel
+from virtool_core.models.enums import Permission
+from virtool_core.models.group import Group
+from virtool_core.models.user import UserNested
+
+
+class Session(BaseModel):
+    created_at: datetime
+    ip: str
+    token: str
+    groups: List[Group]
+    permissions: Permission
+    force_reset: bool
+    user: UserNested
+
+
+

--- a/virtool_core/models/session.py
+++ b/virtool_core/models/session.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from typing import List
+from typing import List, Optional
 
 from virtool_core.models.basemodel import BaseModel
 from virtool_core.models.enums import Permission
@@ -8,14 +8,22 @@ from virtool_core.models.group import Group
 from virtool_core.models.user import UserNested
 
 
-class MinimalSession(BaseModel):
-    created_at: datetime
-    ip: str
-
-
-class Session(MinimalSession):
+class SessionAuthentication(BaseModel):
     token: str
     groups: List[Group]
     permissions: Permission
     force_reset: bool
     user: UserNested
+
+
+class SessionReset(BaseModel):
+    code: str
+    remember: bool
+    user_id: str
+
+
+class Session(BaseModel):
+    authentication: Optional[SessionAuthentication]
+    reset: Optional[SessionReset]
+    created_at: datetime
+    ip: str

--- a/virtool_core/models/session.py
+++ b/virtool_core/models/session.py
@@ -8,9 +8,12 @@ from virtool_core.models.group import Group
 from virtool_core.models.user import UserNested
 
 
-class Session(BaseModel):
+class MinimalSession(BaseModel):
     created_at: datetime
     ip: str
+
+
+class Session(MinimalSession):
     token: str
     groups: List[Group]
     permissions: Permission


### PR DESCRIPTION
Proposed new model for sessions in virtool. 

Varies mildly from current session dictionary in use in that many fields that it uses the `NestedUser` model for the user field. In an effort to reduce redundancy the administrator field is no longer explicitly defined as it is contained with the definition of `NestedUser`.  Possible downside is that it may again be required to define administrator explicitly again should the definition of a `NestedUser` be changed to no longer include the administrator field. 

Alternative approach: Alternatively we could instead define user as an instance of the `User` model which would result in implicit inclusion of most of the variables currently defined in the session object. This approach was not taken due to the inclusion of additional data superfluous to the needs of the session object, requiring more runtime during json (de)conversion.



