### PR TITLE
fix: remove reference field from `OTUSequence`

### DIFF
--- a/virtool_core/models/otu.py
+++ b/virtool_core/models/otu.py
@@ -23,10 +23,27 @@ class OTURemote(BaseModel):
 
 
 class OTUSequence(BaseModel):
+    """
+    An OTU the included in an OTU.
+
+    It does not include a nested reference field as this is included in the parent OTU.
+    """
+
     accession: str
     definition: str
     host: str
     id: str
+    remote: Optional[OTURemote]
+    segment: Optional[str]
+    sequence: str
+
+
+class Sequence(OTUSequence):
+    accession: str
+    definition: str
+    host: str
+    id: str
+    otu_id: str
     reference: ReferenceNested
     remote: Optional[OTURemote]
     segment: Optional[str]

--- a/virtool_core/models/otu.py
+++ b/virtool_core/models/otu.py
@@ -24,7 +24,7 @@ class OTURemote(BaseModel):
 
 class OTUSequence(BaseModel):
     """
-    An OTU the included in an OTU.
+    A sequence nested in an OTU.
 
     It does not include a nested reference field as this is included in the parent OTU.
     """
@@ -39,6 +39,10 @@ class OTUSequence(BaseModel):
 
 
 class Sequence(OTUSequence):
+    """
+    A complete sequence resource as returned for sequence API requests.
+    """
+
     accession: str
     definition: str
     host: str


### PR DESCRIPTION
BREAKING CHANGE: Replace usages of OTUSequence with Sequence. OTUSequence is meant to be nested in OTUs.