### PR TITLE
fix: include full user in UserSearchResult

### DIFF
--- a/virtool_core/models/user.py
+++ b/virtool_core/models/user.py
@@ -39,4 +39,4 @@ class User(UserMinimal):
 
 
 class UserSearchResult(SearchResult):
-    documents: List[UserMinimal]
+    documents: List[User]

--- a/virtool_core/models/user.py
+++ b/virtool_core/models/user.py
@@ -39,4 +39,4 @@ class User(UserMinimal):
 
 
 class UserSearchResult(SearchResult):
-    documents: List[User]
+    items: List[User]


### PR DESCRIPTION
Need a model for returning a paginated list of users from the administrators view.`UserSearchResult` is not currently in use in the codebase. Could add `UserMinimalSearchResult` for the case of getting a list of basic `UserMinimal` objects for display, but we are more likely to want `UserNestedSearchResult` imo

