### PR TITLE
fix!: ensure model type is included in snapshots for testing

### DIFF
--- a/virtool_core/models/basemodel.py
+++ b/virtool_core/models/basemodel.py
@@ -10,3 +10,5 @@ class BaseModel(PydanticBaseModel):
 
     def __eq__(self, other):
         return NotImplemented
+
+    __hash__ = None

--- a/virtool_core/models/basemodel.py
+++ b/virtool_core/models/basemodel.py
@@ -7,3 +7,6 @@ class BaseModel(PydanticBaseModel):
         if "_id" in values:
             values["id"] = values.pop("_id")
         return values
+
+    def __eq__(self, other):
+        return NotImplemented

--- a/virtool_core/models/basemodel.py
+++ b/virtool_core/models/basemodel.py
@@ -11,4 +11,5 @@ class BaseModel(PydanticBaseModel):
     def __eq__(self, other):
         return NotImplemented
 
-    __hash__ = None
+    def __hash__(self):
+        return NotImplemented


### PR DESCRIPTION
This will force snapshots to be compared based on the snapshots __eq__ method as opposed to the base model from pydantic which is what was causing them to all be labelled as dictionaries.

When this is merged the snapshots in virtool will also need to be updated.