### PR TITLE
fix: remove all `administrator` fields

### DIFF
--- a/virtool_core/models/account.py
+++ b/virtool_core/models/account.py
@@ -44,8 +44,7 @@ class Account(User):
 
 class APIKey(BaseModel):
     id: str
-    name: str
-    administrator: bool
-    groups: list[GroupMinimal]
-    permissions: Permissions
     created_at: datetime
+    groups: list[GroupMinimal]
+    name: str
+    permissions: Permissions

--- a/virtool_core/models/reference.py
+++ b/virtool_core/models/reference.py
@@ -34,10 +34,9 @@ class ReferenceGroup(ReferenceRights):
 
 
 class ReferenceUser(ReferenceRights):
-    administrator: bool
+    created_at: datetime
     handle: str
     id: str
-    created_at: datetime
 
 
 class ReferenceContributor(UserNested):


### PR DESCRIPTION
BREAKING CHANGE: Breaks functionality relying on `administrator` flags.