### PR TITLE
fix: support python 3.10 - 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,16 @@
 name = "virtool-core"
 version = "0.2.0"
 description = "Core utilities for Virtool."
-authors = ["Ian Boyes", "Blake Smith"]
+authors = [
+    "Ian Boyes",
+    "Blake Smith",
+    "Aman Monga",
+    "Ryan Fang",
+    "Markus Swoveland",
+    "Reece Hoffmann",
+    "Matt Curtis",
+    "Christine Wong Chong"
+]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/virtool/virtool-core"


### PR DESCRIPTION
This actually just updates the contributors. A previous commit adds support for 3.11 and 3.12.